### PR TITLE
added check to see if connected when web socket is closed

### DIFF
--- a/src/obs-remote.js
+++ b/src/obs-remote.js
@@ -105,7 +105,9 @@
         };
 
         this._socket.onclose = function() {
-            self.onConnectionClosed();
+            if (self._connected) {
+                self.onConnectionClosed();
+            }
             self._connected = false;
         };
 


### PR DESCRIPTION
If OBS-Remote was never connected to OBS, both onConnectionClosed and onConnectionFailed would be called when the connection failed. Adding a check to see if it was connected prevents this from happening.
